### PR TITLE
Désactive les couleurs dans le terminal Jupyter

### DIFF
--- a/.bashrc.custom
+++ b/.bashrc.custom
@@ -1,5 +1,16 @@
 source /cvmfs/soft.computecanada.ca/config/profile/bash.sh
 
+if ! [[ -z $JUPYTER_RUNTIME_DIR ]]; then
+	TERM=xterm-mono
+fi
+
+if [[ $TERM == xterm-mono ]]; then
+	unalias grep egrep fgrep xzegrep xzfgrep zegrep zfgrep zgrep
+	# unalias ls ll l.
+	# alias l.='ls -d .*'
+	# alias ll='ls -l'
+fi
+
 if [[ $HOSTNAME == nodecpu* ]]; then
 	export HOSTNAME=monordi
 	export HOME=/home/$USER/.monordi
@@ -16,4 +27,3 @@ sq() {
 }
 
 export SALLOC_PARTITION="compute-node"
-


### PR DESCRIPTION
Si l’environnement Jupyter est détecté, on demande un terminal monochrome. Tous les programmes utilisant terminfo devraient honorer ce choix. J’ai vérifié que c’est le cas des principaux éditeurs de texte, incluant Nano et Vim, mais pas de GCC.

Puisque `TERM` est préservé par `ssh`, cela fonctionne aussi si on se connecte au nœud de connexion ou à un nœud de calcul. Puisque `TERM` n’est changé que dans l’environnement Jupyter, les connexions qui utilisent un véritable terminal bénéficieront encore des couleurs.

Il reste à désactiver la couleur là où elle a été activée explicitement, soit les alias pour `grep` et `ls`. Cette suppression d’alias doit être faite dans toutes les sessions, même si l’environnement Jupyter n’est plus détecté (connexion à un autre nœud).

Pour le moment, j’ai désactivé les alias `grep` et conservé ceux pour `ls` car je n’ai jamais eu de souci avec la sortie de `ls`. On pourra revisiter ce choix au besoin.